### PR TITLE
WATER-5861 Fix PHP CS Fixer rules wrongly overwritten by our overrides

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -24,7 +24,7 @@ class Config extends BaseConfig
 
     public function getRules(): array
     {
-        return array_merge([
+        $rules = array_merge([
             // Base rule sets
             '@PSR1' => true,
             '@PSR2' => true,
@@ -94,5 +94,10 @@ class Config extends BaseConfig
             'whitespace_after_comma_in_array' => true,
             'yoda_style' => false,
         ], $this->overrides);
+
+        // Order the rule sets: @PSR1, @PSR2, @PSR12 (instead of @PSR1, @PSR12, @PSR2)
+        uksort($rules, "strnatcmp");
+
+        return $rules;
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -96,7 +96,7 @@ class Config extends BaseConfig
         ], $this->overrides);
 
         // Order the rule sets: @PSR1, @PSR2, @PSR12 (instead of @PSR1, @PSR12, @PSR2)
-        uksort($rules, "strnatcmp");
+        uksort($rules, 'strnatcmp');
 
         return $rules;
     }


### PR DESCRIPTION
See https://sandwaveio.atlassian.net/browse/WATER-5861

We can override PHP CS Fixer rules in each of our projects, but these are not properly put in the list of rules. So we might tell it to order the imports (“use” statements) but this is overwritten by the PSR12 rule set because that rule set is put at the end of the config array. And this in turn causes our imports to not be sorted.

tl;dr: Rule sets (that start with an “@“) should be placed on top of the config array.